### PR TITLE
changes to allow multiple rediscache datasources to be used on a site

### DIFF
--- a/src/railo/extension/io/cache/redis/RedisCacheEntry.java
+++ b/src/railo/extension/io/cache/redis/RedisCacheEntry.java
@@ -35,7 +35,7 @@ public class RedisCacheEntry implements CacheEntry{
     }
 
     public String getKey() {
-        return RedisCacheUtils.removeNamespace(item.getKey());
+        return RedisCacheUtils.removeNamespace(item.getCacheName(), item.getKey());
     }
 
     public Object getValue() {

--- a/src/railo/extension/io/cache/redis/RedisCacheItem.java
+++ b/src/railo/extension/io/cache/redis/RedisCacheItem.java
@@ -5,17 +5,23 @@ public class RedisCacheItem{
     Integer hitCount;
     String key;
     String value;
+    
+    private String cacheName;
 
-    public RedisCacheItem(String key, String value) {
+    public RedisCacheItem(String key, String value, String cacheName) {
         setKey(key);
         setValue(value);
         setHitCount(0);
+        
+        this.cacheName = cacheName;
     }
 
-    public RedisCacheItem(String key, String value, Integer hitCount) {
+    public RedisCacheItem(String key, String value, Integer hitCount, String cacheName) {
         setKey(key);
         setValue(value);
         setHitCount(hitCount);
+        
+        this.cacheName = cacheName;
     }
 
 
@@ -41,5 +47,9 @@ public class RedisCacheItem{
 
     public String getValue() {
         return value;
+    }
+    
+    public String getCacheName() {
+    	return cacheName;
     }
 }

--- a/src/railo/extension/io/cache/redis/RedisCacheUtils.java
+++ b/src/railo/extension/io/cache/redis/RedisCacheUtils.java
@@ -5,16 +5,16 @@ public class RedisCacheUtils {
     private RedisCacheUtils() {
     }
 
-    public static String formatKey(String key){
-        if(key.contains(RedisConnection.NAMESPACE)){
+    public static String formatKey(String cacheName, String key){
+        if(key.contains(RedisConnection.getNamespace(cacheName))){
             return key;
         }
-        String res = RedisConnection.NAMESPACE + ':' + key;
+        String res = RedisConnection.getNamespace(cacheName) + ':' + key;
         return res.toLowerCase();
     }
 
-    public static  String removeNamespace(String key){
-        return key.replace(RedisConnection.NAMESPACE + ":", "");
+    public static  String removeNamespace(String cacheName, String key){
+        return key.replace(RedisConnection.getNamespace(cacheName) + ":", "");
 
     }
 

--- a/src/railo/extension/io/cache/redis/RedisConnection.java
+++ b/src/railo/extension/io/cache/redis/RedisConnection.java
@@ -1,33 +1,34 @@
 package railo.extension.io.cache.redis;
 
+import java.util.Hashtable;
+
 import railo.loader.engine.CFMLEngine;
 import railo.loader.engine.CFMLEngineFactory;
 import railo.runtime.type.Struct;
 import railo.runtime.util.Cast;
 import railo.runtime.exp.PageException;
-
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
 public class RedisConnection {
 
-    private static JedisPool instance;
-    public static String NAMESPACE;
+    private static final Hashtable<String, JedisPool> instance = new Hashtable<String, JedisPool>();
+    private static final Hashtable<String, String> namespace = new Hashtable<String, String>();
 
     private RedisConnection() {}
 
-    public static JedisPool init(Struct arguments){
+    public static JedisPool init(String cacheName, Struct arguments){
 
         CFMLEngine engine = CFMLEngineFactory.getInstance();
         Cast caster = engine.getCastUtil();
 
-        if(instance != null){
-            return instance;
+        if(instance != null && instance.contains(cacheName)){
+            return getInstance(cacheName);
         }
 
         try{
-            NAMESPACE = caster.toString(arguments.get("namespace"));
+        	namespace.put(cacheName, caster.toString(arguments.get("namespace")));
 
             String hosts = caster.toString(arguments.get("hosts"));
             String host = hosts.split(":")[0];
@@ -36,19 +37,22 @@ public class RedisConnection {
 
             JedisPoolConfig config = new JedisPoolConfig();
             config.setTestOnBorrow(true);
-
-            instance = new JedisPool(config, host, port);
+            
+            instance.put(cacheName, new JedisPool(config, host, port));
 
         } catch (PageException e) {
             e.printStackTrace();
         }
 
-        return instance;
+        return instance.get(cacheName);
     }
 
-    public static JedisPool getInstance(){
-        return instance;
+    public static JedisPool getInstance(String cacheName){
+        return instance.get(cacheName);
     }
-
+    
+    public static String getNamespace(String cacheName){
+    	return namespace.get(cacheName);
+    }
 
 }


### PR DESCRIPTION
Hi, 

when trying to use more than one rediscache cache on a site the extension would only ever use the first one to be used even if the cache name was different i.e if you used one cache for session storage and another for the object cache everything would go into the session storage cache as it would be the first one to be called.

I've changed the RedisConnection class to store both the JedisPool and namespace inside a hashset and use the cachename as the key and then changed all related calls to pass the cachename as argument
